### PR TITLE
OOMKiller

### DIFF
--- a/helm_templates/cluster_autoscaler.tpl
+++ b/helm_templates/cluster_autoscaler.tpl
@@ -34,7 +34,7 @@ service:
 resources:
   limits:
     cpu: 100m
-    memory: 300Mi
+    memory: 500Mi
   requests:
     cpu: 100m
-    memory: 300Mi
+    memory: 500Mi


### PR DESCRIPTION
The amount of memory needs to be increased to avoid being OOMKilled

With 300Mi setting
----------------------
    State:          Terminated
      Reason:       OOMKilled
      Exit Code:    137
      Started:      Mon, 13 Dec 2021 18:02:32 -0800
      Finished:     Mon, 13 Dec 2021 18:02:42 -0800
    Ready:          False
    Restart Count:  5
    Limits:
      cpu:     100m
      memory:  300Mi
    Requests:
      cpu:     100m
      memory:  300Mi
    Liveness:  http-get http://:8085/health-check delay=0s timeout=1s period=10s #success=1 #failure=3
    Environment:
      AWS_REGION:  us-east-1

With 500Mi
--------------
    State:          Running
      Started:      Mon, 13 Dec 2021 19:45:38 -0800
    Ready:          True
    Restart Count:  0
    Limits:
      cpu:     100m
      memory:  500Mi
    Requests:
      cpu:     100m
      memory:  500Mi
    Liveness:  http-get http://:8085/health-check delay=0s timeout=1s period=10s #success=1 #failure=3
    Environment:
      AWS_REGION:  us-east-1
